### PR TITLE
Add NNpsk2 handshake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ keywords = ["noise", "tokio", "tcp", "ssl", "snow"]
 [dependencies]
 snow = { version = "0.9", default-features = false, features = ["ring-accelerated"] }
 tokio = { version = "1", default-features = false, features = ["io-util", "net"] }
-bytes = { version = "1.6", default-features = false }
 log = { version = "0.4", default-features = false }
 
 [dev-dependencies]
+bytes = { version = "1.6", default-features = false }
 http-body-util = "0.1.1"
 hyper = { version = "1.2.0", features = ["server", "client", "http1"] }
 hyper-util = { version = "0.1.3", features = ["tokio"] }

--- a/src/handshakes/mod.rs
+++ b/src/handshakes/mod.rs
@@ -1,14 +1,17 @@
 //! This module encapsulates an interface for customizing handshake protocols.
 
 use snow::{
-    params::{
-        BaseChoice, CipherChoice, DHChoice, HandshakeChoice, HandshakeModifier,
-        HandshakeModifierList, HandshakePattern, HashChoice, NoiseParams,
-    },
+    params::{CipherChoice, DHChoice, HashChoice},
     HandshakeState,
 };
 
 use crate::errors::{HandshakeError, NoiseError};
+
+pub mod nn_psk0;
+pub mod nn_psk2;
+
+pub use nn_psk0::NNpsk0;
+pub use nn_psk2::NNpsk2;
 
 /// A default choice for the diffie-hellman key-exchange group.
 pub const DEFAULT_DH_CHOICE: DHChoice = DHChoice::Curve25519;
@@ -185,59 +188,5 @@ pub trait Handshake {
             description: description.to_string(),
             handshake_pattern: self.name(),
         }
-    }
-}
-
-/// Represents an `NNpsk0` handshake, where both parties have a pre-shared key (PSK)
-/// which they can use to identify and authenticate each other during the handshake.
-#[derive(Clone, Copy, Debug)]
-pub struct NNpsk0<'a> {
-    /// The pre-shared key (PSK) known to both initiator and responder.
-    pub psk: &'a [u8],
-    /// The cryptographic primitives needed for the handshake.
-    pub choices: CryptoChoices,
-}
-
-impl<'a> NNpsk0<'a> {
-    /// Constructs an `NNpsk0` handshake using the given PSK.
-    pub fn new(psk: &'a [u8]) -> Self {
-        assert!(
-            psk.len() >= 16,
-            "PSK length {} is unsafe, not enough entropy",
-            psk.len()
-        );
-
-        NNpsk0 {
-            psk,
-            choices: CryptoChoices::default(),
-        }
-    }
-
-    /// Constructs an `NNpsk0` handshake using the given PSK and ciphersuite parameters.
-    pub fn new_custom(psk: &'a [u8], choices: CryptoChoices) -> Self {
-        NNpsk0 { psk, choices }
-    }
-}
-
-impl<'a> Handshake for NNpsk0<'a> {
-    fn name(&self) -> String {
-        self.choices.stringify_with_pattern("NNpsk0")
-    }
-
-    fn new_builder(&self) -> snow::Builder {
-        let params = NoiseParams {
-            name: self.name(),
-            base: BaseChoice::Noise,
-            handshake: HandshakeChoice {
-                pattern: HandshakePattern::NN,
-                modifiers: HandshakeModifierList {
-                    list: vec![HandshakeModifier::Psk(0)],
-                },
-            },
-            dh: self.choices.dh,
-            cipher: self.choices.cipher,
-            hash: self.choices.hash,
-        };
-        snow::Builder::new(params).psk(0, self.psk)
     }
 }

--- a/src/handshakes/nn_psk0.rs
+++ b/src/handshakes/nn_psk0.rs
@@ -1,0 +1,60 @@
+use snow::params::{
+    BaseChoice, HandshakeChoice, HandshakeModifier, HandshakeModifierList, HandshakePattern,
+    NoiseParams,
+};
+
+use super::{CryptoChoices, Handshake};
+
+/// Represents an `NNpsk0` handshake, where both parties have a pre-shared key (PSK)
+/// which they can use to identify and authenticate each other during the handshake.
+#[derive(Clone, Copy, Debug)]
+pub struct NNpsk0<'a> {
+    /// The pre-shared key (PSK) known to both initiator and responder.
+    pub psk: &'a [u8],
+    /// The cryptographic primitives needed for the handshake.
+    pub choices: CryptoChoices,
+}
+
+impl<'a> NNpsk0<'a> {
+    /// Constructs an `NNpsk0` handshake using the given PSK.
+    pub fn new(psk: &'a [u8]) -> Self {
+        assert!(
+            psk.len() >= 16,
+            "PSK length {} is unsafe, not enough entropy",
+            psk.len()
+        );
+
+        NNpsk0 {
+            psk,
+            choices: CryptoChoices::default(),
+        }
+    }
+
+    /// Constructs an `NNpsk0` handshake using the given PSK and ciphersuite parameters.
+    pub fn new_custom(psk: &'a [u8], choices: CryptoChoices) -> Self {
+        NNpsk0 { psk, choices }
+    }
+}
+
+impl<'a> Handshake for NNpsk0<'a> {
+    fn name(&self) -> String {
+        self.choices.stringify_with_pattern("NNpsk0")
+    }
+
+    fn new_builder(&self) -> snow::Builder {
+        let params = NoiseParams {
+            name: self.name(),
+            base: BaseChoice::Noise,
+            handshake: HandshakeChoice {
+                pattern: HandshakePattern::NN,
+                modifiers: HandshakeModifierList {
+                    list: vec![HandshakeModifier::Psk(0)],
+                },
+            },
+            dh: self.choices.dh,
+            cipher: self.choices.cipher,
+            hash: self.choices.hash,
+        };
+        snow::Builder::new(params).psk(0, self.psk)
+    }
+}

--- a/src/handshakes/nn_psk0.rs
+++ b/src/handshakes/nn_psk0.rs
@@ -1,3 +1,9 @@
+//! This module encapsulates the [`NNpsk0`] handshake.
+//!
+//! With the `NNpsk0` handshake, both parties know a pre-shared key (PSK)
+//! which is mixed into the handshake before any communication takes place.
+//! Every message is protected by the PSK.
+
 use snow::params::{
     BaseChoice, HandshakeChoice, HandshakeModifier, HandshakeModifierList, HandshakePattern,
     NoiseParams,

--- a/src/handshakes/nn_psk2.rs
+++ b/src/handshakes/nn_psk2.rs
@@ -1,0 +1,152 @@
+use snow::{
+    params::{
+        BaseChoice, HandshakeChoice, HandshakeModifier, HandshakeModifierList, HandshakePattern,
+        NoiseParams,
+    },
+    HandshakeState,
+};
+
+use crate::errors::NoiseError;
+
+use super::{CryptoChoices, Handshake};
+
+#[derive(Clone, Copy, Debug)]
+pub struct Initiator<'p> {
+    /// The identity given in plaintext to the responder.
+    pub identity: &'p [u8],
+    /// The PSK which will be mixed into the handshake after the first initial message.
+    /// The responder should be able to look up the same PSK using the value of the
+    /// [`Initiator::identity`] field.
+    pub psk: &'p [u8],
+}
+
+#[derive(Clone, Debug)]
+pub struct Responder<F: FnMut(&[u8]) -> Option<&[u8]>> {
+    find_psk: F,
+    initiator_identity: Option<Vec<u8>>,
+}
+
+impl<F: FnMut(&[u8]) -> Option<&[u8]>> Responder<F> {
+    pub fn new(find_psk: F) -> Self {
+        Responder {
+            find_psk,
+            initiator_identity: None,
+        }
+    }
+
+    pub fn initiator_identity(&self) -> Option<&[u8]> {
+        self.initiator_identity.as_ref().map(|vec| vec.as_ref())
+    }
+}
+
+/// Represents an `NNpsk2` handshake, where the initiator already knows a PSK, but
+/// must identify themselves in cleartext to the responder in order for the responder
+/// to also find that same PSK.
+#[derive(Clone, Debug)]
+pub struct NNpsk2<P> {
+    /// The party object, which looks up the PSK for the handshake. This should either
+    /// be an [`Initiator`] or a [`Responder`].
+    pub party: P,
+    /// The cryptographic primitives needed for the handshake.
+    pub choices: CryptoChoices,
+}
+
+impl<P> NNpsk2<P> {
+    /// Constructs an `NNpsk2` handshake for the given party, which should either be
+    /// an [`Initiator`] or a [`Responder`].
+    pub fn new(party: P) -> Self {
+        NNpsk2 {
+            party,
+            choices: CryptoChoices::default(),
+        }
+    }
+
+    /// Constructs an `NNpsk2` handshake for the given party, which should either be
+    /// an [`Initiator`] or a [`Responder`]. Allows customizing the ciphersuite parameters.
+    pub fn new_custom(party: P, choices: CryptoChoices) -> Self {
+        NNpsk2 { party, choices }
+    }
+}
+
+impl Handshake for NNpsk2<Initiator<'_>> {
+    fn name(&self) -> String {
+        self.choices.stringify_with_pattern("NNpsk2")
+    }
+
+    fn new_builder(&self) -> snow::Builder {
+        let params = NoiseParams {
+            name: self.name(),
+            base: BaseChoice::Noise,
+            handshake: HandshakeChoice {
+                pattern: HandshakePattern::NN,
+                modifiers: HandshakeModifierList {
+                    list: vec![HandshakeModifier::Psk(2)],
+                },
+            },
+            dh: self.choices.dh,
+            cipher: self.choices.cipher,
+            hash: self.choices.hash,
+        };
+        snow::Builder::new(params)
+    }
+
+    fn initiator_first_message(
+        &mut self,
+        initiator: &mut HandshakeState,
+        send_buf: &mut [u8],
+    ) -> Result<usize, NoiseError> {
+        if self.party.identity.len() > send_buf.len() {
+            return Err(self.error(format!(
+                "initiator identity size exceeds send buffer size ({} bytes)",
+                send_buf.len()
+            )))?;
+        }
+        let n = initiator.write_message(self.party.identity, send_buf)?;
+        initiator.set_psk(2, self.party.psk)?;
+        Ok(n)
+    }
+}
+
+impl<F: FnMut(&[u8]) -> Option<&[u8]>> Handshake for NNpsk2<&mut Responder<F>> {
+    fn name(&self) -> String {
+        self.choices.stringify_with_pattern("NNpsk2")
+    }
+
+    fn new_builder(&self) -> snow::Builder {
+        let params = NoiseParams {
+            name: self.name(),
+            base: BaseChoice::Noise,
+            handshake: HandshakeChoice {
+                pattern: HandshakePattern::NN,
+                modifiers: HandshakeModifierList {
+                    list: vec![HandshakeModifier::Psk(2)],
+                },
+            },
+            dh: self.choices.dh,
+            cipher: self.choices.cipher,
+            hash: self.choices.hash,
+        };
+        snow::Builder::new(params)
+    }
+
+    fn responder_first_message(
+        &mut self,
+        responder: &mut HandshakeState,
+        recv_buf: &[u8],
+        send_buf: &mut [u8],
+    ) -> Result<usize, NoiseError> {
+        // Assume the initiator sent us their identity
+        let initiator_identity = &recv_buf[..];
+
+        if initiator_identity.len() == 0 {
+            return Err(self.error("initiator did not send us their identity to look up a PSK"))?;
+        }
+
+        let psk = (self.party.find_psk)(initiator_identity)
+            .ok_or_else(|| self.error("found no PSK for initiator"))?;
+
+        self.party.initiator_identity = Some(Vec::from(initiator_identity));
+        responder.set_psk(2, psk)?;
+        Ok(responder.write_message(&[], send_buf)?)
+    }
+}

--- a/tests/nn_psk2.rs
+++ b/tests/nn_psk2.rs
@@ -1,10 +1,27 @@
 use tokio::net::{TcpListener, TcpStream};
-use tokio_noise::{NoiseError, NoiseTcpStream};
+use tokio_noise::{
+    handshakes::{nn_psk2, NNpsk2},
+    NoiseError, NoiseTcpStream,
+};
 
 const PSK: [u8; 32] = [0xFF; 32];
 
 async fn run_noise_server(tcp_stream: TcpStream) -> Result<(), NoiseError> {
-    let mut noise_stream = NoiseTcpStream::handshake_responder_psk0(tcp_stream, &PSK).await?;
+    let mut responder = nn_psk2::Responder::new(|id: &[u8]| -> Option<&[u8]> {
+        if id != b"client_id_123".as_ref() {
+            return None;
+        }
+        Some(&PSK)
+    });
+
+    let mut noise_stream =
+        NoiseTcpStream::handshake_responder(tcp_stream, NNpsk2::new(&mut responder)).await?;
+
+    assert_eq!(
+        responder.initiator_identity(),
+        Some(b"client_id_123".as_ref())
+    );
+
     let mut buf = [0u8; 1024];
     let n = noise_stream.recv(&mut buf).await?;
     assert_eq!(&buf[..n], b"hello world");
@@ -22,8 +39,13 @@ async fn main() -> Result<(), NoiseError> {
     });
 
     // Client
+    let initiator = nn_psk2::Initiator {
+        psk: &PSK,
+        identity: b"client_id_123",
+    };
     let tcp_stream = TcpStream::connect(&addr).await?;
-    let mut noise_stream = NoiseTcpStream::handshake_initiator_psk0(tcp_stream, &PSK).await?;
+    let mut noise_stream =
+        NoiseTcpStream::handshake_initiator(tcp_stream, NNpsk2::new(initiator)).await?;
     noise_stream.send(b"hello world").await?;
 
     // Wait for server to finish


### PR DESCRIPTION
This handshake is used when the responder doesn't already know which PSK to use, and requires a prompt, or 'identity' message from the initiator to find the right PSK.